### PR TITLE
fix: make form shortcode compatible with old and new Hugo

### DIFF
--- a/layouts/shortcodes/form.html
+++ b/layouts/shortcodes/form.html
@@ -3,8 +3,29 @@
     {{ errorf "Module 'forms' is not enabled for this page. Please add 'forms' to the 'modules' array in the frontmatter." }}
 {{ end }}
 
+{{ if lt (len .Params) 1 }}
+    {{ errorf "The form shortcode requires a form name argument." }}
+{{ end }}
+
 {{ $formName := .Get 0 }}
-{{ $form := index .Site.Data.forms $formName }}
+{{ if not $formName }}
+    {{ errorf "The form shortcode requires a non-empty form name argument." }}
+{{ end }}
+
+{{ $forms := dict }}
+{{ if ge hugo.Version "0.156.0" }}
+    {{ $forms = index hugo.Data "forms" }}
+{{ else }}
+    {{ $forms = .Site.Data.forms }}
+{{ end }}
+{{ if not $forms }}
+    {{ errorf "The form shortcode requires form data under data/forms." }}
+{{ end }}
+
+{{ $form := index $forms $formName }}
+{{ if not $form }}
+    {{ errorf "The form shortcode could not find form %q in data/forms." $formName }}
+{{ end }}
 
 
 <h2 class="heading" id="form-heading">{{ $form.form.title }}</h2>


### PR DESCRIPTION
## Summary
- make the `form` shortcode work on both pre-`0.156` Hugo and `0.160+`
- keep the public shortcode API and existing form markup unchanged
- add explicit guards for missing shortcode arg, missing `data/forms`, and missing form name

## Details
- use `hugo.Data` on Hugo `0.156+`
- fall back to `.Site.Data.forms` on older Hugo where `hugo.Data` is unavailable
- avoid `.Site.Data` deprecation warnings on new Hugo happy-path builds

## Verification
- rendered shortcode successfully with Hugo `0.149.0`
- rendered shortcode successfully with Hugo `0.160.0`
- verified guard errors on both versions for:
  - missing shortcode arg
  - missing `data/forms`
  - missing form entry